### PR TITLE
fix: use correct event attributes index when processing span events

### DIFF
--- a/store/reader.go
+++ b/store/reader.go
@@ -302,10 +302,8 @@ func (s *Store) convertClickhouseToJaegerTrace(ctx context.Context, chTrace *cli
 				log.Timestamp = sp.EventsTimestamp[idx]
 				log.Fields = make([]model.KeyValue, 0, len(sp.EventsAttributes)+1)
 				log.Fields = append(log.Fields, model.String("event", value))
-				for i := range sp.EventsAttributes {
-					for k, v := range sp.EventsAttributes[i] {
-						log.Fields = append(log.Fields, model.String(k, v))
-					}
+				for k, v := range sp.EventsAttributes[idx] {
+					log.Fields = append(log.Fields, model.String(k, v))
 				}
 				logs = append(logs, log)
 			}


### PR DESCRIPTION
According to the code of `otelcol`: time, name, attrs should have the same idx

https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/7901da40bb6a45d412460949ce360208129e80f9/exporter/clickhouseexporter/exporter_traces.go#L129


Before, it will be like this: All logs in a span are same:
<img width="1493" alt="image" src="https://github.com/user-attachments/assets/675e1a53-a610-4827-93a2-53313e633c61" />

After fix:
<img width="1475" alt="image" src="https://github.com/user-attachments/assets/8000d0fd-b79a-430e-af3e-dcf1277d2462" />
